### PR TITLE
Fix #6

### DIFF
--- a/crates/rmcp-macros/src/tool.rs
+++ b/crates/rmcp-macros/src/tool.rs
@@ -245,7 +245,7 @@ pub(crate) fn tool(attr: TokenStream, input: TokenStream) -> syn::Result<TokenSt
             }
             ToolParams::NoParam => {
                 quote! {
-                    rmcp::model::JsonObject::new()
+                    rmcp::handler::server::tool::cached_schema_for_type::<rmcp::model::EmptyObject>()
                 }
             }
         };

--- a/crates/rmcp/tests/test_tool_macros.rs
+++ b/crates/rmcp/tests/test_tool_macros.rs
@@ -32,6 +32,8 @@ impl Server {
         drop(city);
         "rain".to_string()
     }
+    #[tool(description = "Empty Parameter")]
+    async fn empty_param(&self) {}
 }
 
 #[tokio::test]
@@ -41,6 +43,23 @@ async fn test_tool_macros() {
     let _get_weather_call_fn = Server::get_weather_tool_call;
     let _get_weather_fn = Server::get_weather;
     server.get_weather("harbin".into()).await;
+}
+
+#[tokio::test]
+async fn test_tool_macros_with_empty_param() {
+    let _attr = Server::empty_param_tool_attr();
+    println!("{_attr:?}");
+    assert_eq!(_attr.input_schema.get("type").unwrap(), "object");
+    assert!(
+        _attr
+            .input_schema
+            .get("properties")
+            .unwrap()
+            .as_object()
+            .as_ref()
+            .unwrap()
+            .is_empty()
+    );
 }
 
 impl GetWeatherRequest {}


### PR DESCRIPTION
Use `rmcp::handler::server::tool::cached_schema_for_type::<rmcp::model::EmptyObject>()` to create schema for empty tool call input.